### PR TITLE
fix: Cloudflare Workers compatibility_dateを更新

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "nudel-website",
   "main": ".open-next/worker.js",
-  "compatibility_date": "2025-01-01",
+  "compatibility_date": "2026-02-21",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
     "directory": ".open-next/assets",


### PR DESCRIPTION
## Summary

- resendパッケージが使用する`WeakRef` APIがCloudflare Workersランタイムで利用できず、メール送信が500エラーになっていた問題を修正
- `compatibility_date`を`2025-01-01`から`2026-02-21`に更新

## Test plan

- [x] 本番環境でお問い合わせフォームからのメール送信が正常に動作することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)