### PR TITLE
fix: IMAGES バインディングを追加して画像最適化の警告を解消

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,9 +8,6 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
-  "images": {
-    "binding": "IMAGES"
-  },
   "observability": {
     "enabled": false,
     "head_sampling_rate": 1,
@@ -31,10 +28,16 @@
       "name": "nudel-website-alpha",
       "routes": [
         { "pattern": "alpha.nudel.co.jp", "custom_domain": true }
-      ]
+      ],
+      "images": {
+        "binding": "IMAGES"
+      }
     },
     "prod": {
-      "name": "nudel-website"
+      "name": "nudel-website",
+      "images": {
+        "binding": "IMAGES"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `wrangler.jsonc` に Cloudflare Images 用の `IMAGES` バインディングを追加
- `/_next/image` アクセス時の `env.IMAGES binding is not defined` 警告を解消
- これにより Cloudflare の画像最適化（Image Resizing）が有効になる

## Background
本番ログで以下の警告が確認されていた：
```
env.IMAGES binding is not defined
```
`@opennextjs/cloudflare` が画像最適化時に `env.IMAGES` バインディングを参照するが、`wrangler.jsonc` に定義がなかったことが原因。

## Test plan
- [x] alpha 環境にデプロイし、`/_next/image` 経由の画像が正常に表示されることを確認
- [x] Workers ログで `env.IMAGES binding is not defined` 警告が出なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)