### PR TITLE
fix: service.icon配列が空の場合のランタイムエラーを修正

### DIFF
--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -39,7 +39,8 @@ export default async function ServiceDetailPage({ params }: Props) {
     notFound();
   }
 
-  const Icon = ICON_MAP[service.icon[0]];
+  const iconKey = service.icon[0];
+  const Icon = iconKey ? ICON_MAP[iconKey] : null;
   const { contents: works } = await getWorksByServiceId(service.id);
 
   return (
@@ -55,9 +56,11 @@ export default async function ServiceDetailPage({ params }: Props) {
         </Link>
 
         <div className="flex items-center gap-4 mb-8">
-          <div className="text-orange-500 bg-orange-50 w-14 h-14 rounded-2xl flex items-center justify-center shadow-sm">
-            <Icon className="w-6 h-6" />
-          </div>
+          {Icon && (
+            <div className="text-orange-500 bg-orange-50 w-14 h-14 rounded-2xl flex items-center justify-center shadow-sm">
+              <Icon className="w-6 h-6" />
+            </div>
+          )}
           <h1 className="text-3xl md:text-5xl font-black tracking-tighter uppercase font-serif italic text-gray-900">
             {service.title}
           </h1>


### PR DESCRIPTION
## 概要

`ICON_MAP[service.icon[0]]` で `icon` 配列が空の場合に `undefined` が返され、JSXでランタイムエラーが発生する問題を修正。`service-card.tsx` と同様の null チェックパターンに統一。

## 変更内容

- `src/app/services/[slug]/page.tsx` のアイコン取得ロジックに null チェックを追加
- アイコンが存在しない場合はアイコン要素を非表示に

## 関連レビュー指摘

PR #25 レビュー — **High #2**