### PR TITLE
fix: Work.description/dateとService.detailDescriptionをoptionalに修正

### DIFF
--- a/src/lib/microcms/types.ts
+++ b/src/lib/microcms/types.ts
@@ -8,7 +8,8 @@ export type Service = {
   description: string;
   icon: ServiceIcon[];
   image: MicroCMSImage;
-  detailDescription: string;
+  /** microCMSで未入力の場合は undefined になる */
+  detailDescription?: string;
   order: number;
 } & MicroCMSListContent;
 
@@ -16,8 +17,10 @@ export type Work = {
   title: string;
   service: Service;
   thumbnail?: MicroCMSImage;
-  description: string;
+  /** microCMSで未入力の場合は undefined になる */
+  description?: string;
   clientName?: string;
-  date: string;
+  /** microCMSで未入力の場合は undefined になる */
+  date?: string;
   order: number;
 } & MicroCMSListContent;


### PR DESCRIPTION
## 概要

`page.tsx` では `work.description`、`work.date`、`service.detailDescription` を条件付きレンダリングしているにも関わらず、型定義では必須フィールドになっていた問題を修正。microCMS で未入力の場合の実態に合わせてオプショナルフィールドに変更。

## 変更内容

- `src/lib/microcms/types.ts` の `Work.description`、`Work.date`、`Service.detailDescription` を optional (`?`) に変更

## 関連レビュー指摘

PR #25 レビュー — **Medium #3**