### PR TITLE
fix: microCMSクライアントのシングルトンをテスト間でリセット可能に

### DIFF
--- a/src/lib/microcms/client.test.ts
+++ b/src/lib/microcms/client.test.ts
@@ -12,11 +12,18 @@ vi.mock("microcms-js-sdk", () => ({
 vi.stubEnv("MICROCMS_SERVICE_DOMAIN", "test-domain");
 vi.stubEnv("MICROCMS_API_KEY", "test-api-key");
 
-import { getServices, getServiceBySlug, getWorksByServiceId } from "./client";
+import {
+  getServices,
+  getServiceBySlug,
+  getWorksByServiceId,
+  _resetClientForTesting,
+} from "./client";
 
 describe("microCMS client", () => {
   beforeEach(() => {
     mockGetList.mockReset();
+    // テスト間でシングルトンが残留しないようにリセット
+    _resetClientForTesting();
   });
 
   describe("getServices", () => {

--- a/src/lib/microcms/client.ts
+++ b/src/lib/microcms/client.ts
@@ -23,6 +23,11 @@ function getClient(): Client {
   return _client;
 }
 
+/** テスト用：シングルトンをリセットして次回呼び出し時に再初期化させる */
+export function _resetClientForTesting(): void {
+  _client = null;
+}
+
 /** サービス一覧取得（order昇順） */
 export async function getServices(queries?: MicroCMSQueries) {
   return getClient().getList<Service>({


### PR DESCRIPTION
## 概要

モジュールレベルのシングルトン `_client` がテスト間で残留し、環境変数を変更するテストケースを追加する際に不具合の原因になりうる問題を修正。

## 変更内容

- `src/lib/microcms/client.ts` に `_resetClientForTesting()` をエクスポート
- `src/lib/microcms/client.test.ts` の `beforeEach` で `_resetClientForTesting()` を呼び出し

## 関連レビュー指摘

PR #25 レビュー — **Low #6**