### PR TITLE
feat: generateStaticParamsでサービス詳細ページをビルド時に事前生成

### DIFF
--- a/src/app/services/[slug]/page.tsx
+++ b/src/app/services/[slug]/page.tsx
@@ -3,7 +3,11 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
-import { getServiceBySlug, getWorksByServiceId } from "@/lib/microcms/client";
+import {
+  getServiceBySlug,
+  getServices,
+  getWorksByServiceId,
+} from "@/lib/microcms/client";
 import { ICON_MAP } from "@/lib/microcms/icon-map";
 import type { Work } from "@/lib/microcms/types";
 import { SITE_CONFIG } from "@/lib/constants";
@@ -11,6 +15,17 @@ import { SITE_CONFIG } from "@/lib/constants";
 type Props = {
   params: Promise<{ slug: string }>;
 };
+
+/** ビルド時にサービスページのパラメータを事前生成する */
+export async function generateStaticParams() {
+  try {
+    const { contents } = await getServices({ limit: 100 });
+    return contents.map((service) => ({ slug: service.slug }));
+  } catch {
+    // ビルド時にAPIが利用できない場合は空配列を返す（SSRにフォールバック）
+    return [];
+  }
+}
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;


### PR DESCRIPTION
## 概要

`generateStaticParams` を追加し、ビルド時にmicroCMSからスラッグ一覧を取得してサービス詳細ページを静的プリレンダリング。API取得失敗時は空配列を返しSSRにフォールバックするため、ビルドが中断されることはない。

## 変更内容

- `src/app/services/[slug]/page.tsx` に `generateStaticParams` を追加
- `getServices` のインポートを追加

## 関連レビュー指摘

PR #25 レビュー — **Low #7**