### PR TITLE
e2eテスト: 実装との差分を埋める不足テストを追加

### DIFF
--- a/e2e/contact-form.spec.ts
+++ b/e2e/contact-form.spec.ts
@@ -31,6 +31,9 @@ test.describe("Contact form", () => {
     await page.getByRole("button", { name: /send/i }).click();
 
     await expect(page.getByText("お問い合わせありがとうございます。")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("内容を確認の上、担当者よりご連絡いたします。")).toBeVisible({
+      timeout: 10000,
+    });
   });
 
   test("shows error message on failed submission", async ({ page }) => {
@@ -56,6 +59,20 @@ test.describe("Contact form", () => {
 
     const nameInput = page.getByPlaceholder("YOUR NAME");
     const isInvalid = await nameInput.evaluate(
+      (el) => !(el as HTMLInputElement).validity.valid,
+    );
+    expect(isInvalid).toBe(true);
+  });
+
+  test("validates email format", async ({ page }) => {
+    await page.getByPlaceholder("YOUR NAME").fill("テスト太郎");
+    await page.getByPlaceholder("YOUR EMAIL").fill("invalid-email");
+    await page.getByPlaceholder("HOW CAN WE HELP?").fill("テストメッセージ");
+
+    await page.getByRole("button", { name: /send/i }).click();
+
+    const emailInput = page.getByPlaceholder("YOUR EMAIL");
+    const isInvalid = await emailInput.evaluate(
       (el) => !(el as HTMLInputElement).validity.valid,
     );
     expect(isInvalid).toBe(true);

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -22,9 +22,64 @@ test.describe("Home page sections", () => {
       await expect(contact).toBeVisible();
       await expect(contact).toHaveAttribute("href", "#contact");
     });
+
+    test("displays subtitle text", async ({ page }) => {
+      await expect(
+        page.getByText("企業や個人の魅力を見つけ形にするクリエイティブパートナー"),
+      ).toBeVisible();
+    });
+  });
+
+  test.describe("Strength", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.locator("#strength").scrollIntoViewIfNeeded();
+    });
+
+    test("displays section heading", async ({ page }) => {
+      const heading = page.locator("#strength").getByRole("heading", { level: 2 });
+      await expect(heading).toContainText("バラバラを、");
+      await expect(heading).toContainText("ひとつに繋ぐ。");
+    });
+
+    test("displays three strength cards", async ({ page }) => {
+      const strength = page.locator("#strength");
+      await expect(strength.getByText("圧倒的スピード")).toBeVisible();
+      await expect(strength.getByText("一貫したクオリティ")).toBeVisible();
+      await expect(strength.getByText("スペシャリストが所属")).toBeVisible();
+    });
+  });
+
+  test.describe("Founder", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.locator("#founder").scrollIntoViewIfNeeded();
+    });
+
+    test("displays founder name and title", async ({ page }) => {
+      const founder = page.locator("#founder");
+      await expect(founder.getByText("岡崎 美玖")).toBeVisible();
+      await expect(founder.getByText("代表")).toBeVisible();
+    });
+  });
+
+  test.describe("Member", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.locator("#member").scrollIntoViewIfNeeded();
+    });
+
+    test("displays team members with titles", async ({ page }) => {
+      const member = page.locator("#member");
+      await expect(member.getByText("KO", { exact: true }).first()).toBeVisible();
+      await expect(member.getByText("CCO", { exact: true })).toBeVisible();
+      await expect(member.getByText("深津 蓮")).toBeVisible();
+      await expect(member.getByText("CTO", { exact: true })).toBeVisible();
+    });
   });
 
   test.describe("Services", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.locator("#services").scrollIntoViewIfNeeded();
+    });
+
     test("displays service cards", async ({ page }) => {
       const services = page.locator("#services");
 
@@ -33,6 +88,11 @@ test.describe("Home page sections", () => {
       await expect(cards.first()).toBeVisible();
       const count = await cards.count();
       expect(count).toBeGreaterThan(0);
+    });
+
+    test("displays section heading badge", async ({ page }) => {
+      const services = page.locator("#services");
+      await expect(services.getByText("What We Do")).toBeVisible();
     });
   });
 
@@ -43,6 +103,11 @@ test.describe("Home page sections", () => {
       await expect(company.getByText("COMPANY")).toBeVisible();
       await expect(company.getByText("DECK")).toBeVisible();
     });
+
+    test("displays company deck iframe", async ({ page }) => {
+      const iframe = page.locator("#company").locator("iframe[title='Company Deck']");
+      await expect(iframe).toBeAttached();
+    });
   });
 
   test.describe("Footer", () => {
@@ -52,6 +117,21 @@ test.describe("Home page sections", () => {
 
     test("displays copyright", async ({ page }) => {
       await expect(page.locator("footer").getByText(/© \d{4} Nudel LLC/)).toBeVisible();
+    });
+
+    test("displays social links with correct hrefs", async ({ page }) => {
+      const footer = page.locator("footer");
+
+      const twitterLink = footer.getByRole("link", { name: "Twitter (X)" });
+      await expect(twitterLink).toBeVisible();
+      await expect(twitterLink).toHaveAttribute("href", "https://x.com/aaamiku39");
+
+      const instagramLink = footer.getByRole("link", { name: "Instagram" });
+      await expect(instagramLink).toBeVisible();
+      await expect(instagramLink).toHaveAttribute(
+        "href",
+        "https://www.instagram.com/ramen_miku39_/",
+      );
     });
   });
 });

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -22,6 +22,12 @@ test.describe("Navigation", () => {
       await expect(contactBtn).toBeVisible();
       await expect(contactBtn).toHaveAttribute("href", "/#contact");
     });
+
+    test("logo links to home page", async ({ page }) => {
+      const logo = page.locator("nav").getByRole("link", { name: "Nudel" });
+      await expect(logo).toBeVisible();
+      await expect(logo).toHaveAttribute("href", "/");
+    });
   });
 
   test.describe("Mobile", () => {
@@ -43,6 +49,15 @@ test.describe("Navigation", () => {
 
       await closeBtn.click();
       await expect(page.getByRole("button", { name: "メニューを開く" })).toBeVisible();
+    });
+
+    test("mobile Contact link has correct href", async ({ page }) => {
+      const openBtn = page.getByRole("button", { name: "メニューを開く" });
+      await openBtn.click();
+
+      const contactLink = page.getByRole("link", { name: "CONTACT" });
+      await expect(contactLink).toBeVisible();
+      await expect(contactLink).toHaveAttribute("href", "/#contact");
     });
   });
 });

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -16,6 +16,8 @@ test.describe("Smoke tests", () => {
 
     await expect(page.locator("nav")).toBeVisible();
     await expect(page.locator("#strength")).toBeVisible();
+    await expect(page.locator("#founder")).toBeVisible();
+    await expect(page.locator("#member")).toBeVisible();
     await expect(page.locator("#services")).toBeVisible();
     await expect(page.locator("#company")).toBeVisible();
     await expect(page.locator("#contact")).toBeVisible();
@@ -32,5 +34,15 @@ test.describe("Smoke tests", () => {
     const data = JSON.parse(content!);
     expect(data["@type"]).toBe("Organization");
     expect(data.name).toBe("Nudel LLC");
+  });
+
+  test("robots.txt is accessible", async ({ page }) => {
+    const response = await page.goto("/robots.txt");
+    expect(response?.status()).toBe(200);
+  });
+
+  test("sitemap.xml is accessible", async ({ page }) => {
+    const response = await page.goto("/sitemap.xml");
+    expect(response?.status()).toBe(200);
   });
 });


### PR DESCRIPTION
以下のセクション・機能に対するE2Eテストが不足していたため追加:

- home.spec.ts: Heroサブタイトル、Strengthセクション見出し・3カード、
  Founderセクション（新規）、Memberセクション（新規）、
  Servicesバッジ見出し、Company Deck iframe、フッターSNSリンク
- navigation.spec.ts: ナビロゴのhref、モバイルCONTACTリンクのhref
- contact-form.spec.ts: メールフォーマットバリデーション、送信成功時のサブテキスト
- smoke.spec.ts: #founder・#memberセクション存在確認、robots.txt・sitemap.xml疎通確認

https://claude.ai/code/session_01DKUWNYEon21NhdHW3b9J5i