### PR TITLE
fix: CONTACTへのスクロール位置を修正

### DIFF
--- a/src/components/sections/company-section.tsx
+++ b/src/components/sections/company-section.tsx
@@ -29,7 +29,7 @@ export function CompanySection() {
 
           </div>
 
-          <div id="contact" className="relative">
+          <div id="contact" className="relative scroll-mt-24">
             <ContactFormCard />
           </div>
         </div>

--- a/src/components/sections/contact-form.tsx
+++ b/src/components/sections/contact-form.tsx
@@ -25,7 +25,7 @@ export function ContactFormCard() {
   };
 
   return (
-    <div className="sticky top-32 p-12 bg-white rounded-[40px] border border-orange-100 shadow-[0_40px_100px_rgba(255,107,0,0.08)]">
+    <div className="lg:sticky lg:top-28 p-12 bg-white rounded-[40px] border border-orange-100 shadow-[0_40px_100px_rgba(255,107,0,0.08)]">
       <div className="flex items-center gap-4 mb-8">
         <div className="w-12 h-12 bg-orange-500 rounded-2xl flex items-center justify-center shadow-lg shadow-orange-200">
           <MessageCircle size={24} className="text-white" />


### PR DESCRIPTION
- #contact div に scroll-mt-24 を追加し、固定ナビバーに隠れないよう調整
- ContactFormCard の sticky をデスクトップ限定 (lg:sticky) に変更し、モバイルでの位置ずれを解消

https://claude.ai/code/session_01WQG6MckSJ3pfZVPHPiM519