### PR TITLE
test(e2e): fix strict mode violations (Founder, Mobile Contact)

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -57,7 +57,7 @@ test.describe("Home page sections", () => {
     test("displays founder name and title", async ({ page }) => {
       const founder = page.locator("#founder");
       await expect(founder.getByText("岡崎 美玖")).toBeVisible();
-      await expect(founder.getByText("代表")).toBeVisible();
+      await expect(founder.getByText("代表", { exact: true })).toBeVisible();
     });
   });
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -55,7 +55,7 @@ test.describe("Navigation", () => {
       const openBtn = page.getByRole("button", { name: "メニューを開く" });
       await openBtn.click();
 
-      const contactLink = page.getByRole("link", { name: "CONTACT" });
+      const contactLink = page.locator("nav").getByRole("link", { name: "CONTACT" });
       await expect(contactLink).toBeVisible();
       await expect(contactLink).toHaveAttribute("href", "/#contact");
     });


### PR DESCRIPTION
## Summary
main 上で pre-existing で落ちていた E2E テスト 2 件を修正する。直近 #133 マージ後の `Run #25332376088` だけでなく、その前 `Run #25042884934`（#119 マージ時）でも同じ 2 件が落ちていることを確認済み。

## 修正内容
- `e2e/home.spec.ts:60` — `#founder` セクション内の「代表」が badge `<span>代表</span>` と bio 本文中の「…代表に就任。」で 2 要素にマッチしていたため `exact: true` を付与
- `e2e/navigation.spec.ts:58` — モバイル時に「CONTACT」リンクが nav と Concept セクションの 2 要素にマッチしていたため、`page.locator("nav").getByRole(...)` で nav 配下にスコープ

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (151 / 151 passed)
- [ ] PR Preview で当該テストが通ることを確認